### PR TITLE
Add support for specifying MIME sub-type in send()

### DIFF
--- a/src/ezgmail/__init__.py
+++ b/src/ezgmail/__init__.py
@@ -428,10 +428,10 @@ def init(userId="me", tokenFile="token.json", credentialsFile="credentials.json"
             return False
 
 
-def _createMessage(sender, recipient, subject, body, cc=None, bcc=None):
+def _createMessage(sender, recipient, subject, body, cc=None, bcc=None, mime_subtype="plain"):
     """Creates a MIMEText object and returns it as a base64 encoded string in a ``{'raw': b64_MIMEText_object} ``
     dictionary, suitable for use by ``_sendMessage()`` and the ``users.messages.send()`` Gmail API."""
-    message = MIMEText(body, "plain")
+    message = MIMEText(body, mime_subtype)
     message["to"] = recipient
     message["from"] = sender
     message["subject"] = subject
@@ -442,7 +442,7 @@ def _createMessage(sender, recipient, subject, body, cc=None, bcc=None):
     return {"raw": base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")}
 
 
-def _createMessageWithAttachments(sender, recipient, subject, body, attachments, cc=None, bcc=None):
+def _createMessageWithAttachments(sender, recipient, subject, body, attachments, cc=None, bcc=None, mime_subtype="plain"):
     """Creates a MIMEText object and returns it as a base64 encoded string in a ``{'raw': b64_MIMEText_object}``
     dictionary, suitable for use by ``_sendMessage()`` and the ``users.messages.send()`` Gmail API. File attachments can
     also be added to this message.
@@ -462,7 +462,7 @@ def _createMessageWithAttachments(sender, recipient, subject, body, attachments,
     if bcc is not None:
         message["bcc"] = bcc
 
-    messageMimeTextPart = MIMEText(body, "plain")
+    messageMimeTextPart = MIMEText(body, mime_subtype)
     message.attach(messageMimeTextPart)
 
     if isinstance(attachments, str):
@@ -509,7 +509,7 @@ def _sendMessage(message, userId="me"):
     return message
 
 
-def send(recipient, subject, body, attachments=None, sender=None, cc=None, bcc=None):
+def send(recipient, subject, body, attachments=None, sender=None, cc=None, bcc=None, mime_subtype=None):
     """Sends an email from the configured Gmail account."""
     if SERVICE_GMAIL is None:
         init()
@@ -517,10 +517,13 @@ def send(recipient, subject, body, attachments=None, sender=None, cc=None, bcc=N
     if sender is None:
         sender = EMAIL_ADDRESS
 
+    if mime_subtype is None:
+        mime_subtype = "plain"
+
     if attachments is None:
-        msg = _createMessage(sender, recipient, subject, body, cc, bcc)
+        msg = _createMessage(sender, recipient, subject, body, cc, bcc, mime_subtype)
     else:
-        msg = _createMessageWithAttachments(sender, recipient, subject, body, attachments, cc, bcc)
+        msg = _createMessageWithAttachments(sender, recipient, subject, body, attachments, cc, bcc, mime_subtype)
     _sendMessage(msg)
 
 


### PR DESCRIPTION
Hello,

I wanted to add HTML to my sent messages, and so added some simple logic ([per StackOverflow](https://stackoverflow.com/a/41403459)) to specify the MIME sub-type for the text body when sending an email.

I believe this fits within the simplistic interface EZGmail presents. It requires no changes for existing users, and a single keyword argument allows for HTML in emails.

The function can be called like so:
`ezgmail.send(recipient, subject, body, mime_subtype='html')`

The resulting email, in plain text and a screenshot from Gmail:
```
Delivered-To: ...@gmail.com
from: Robot <...@gmail.com>
Subject: This is a subject with footer
To: ...@gmail.com
Content-Type: multipart/alternative; boundary="000000000000410b9505ac009d02"

--000000000000410b9505ac009d02
Content-Type: text/plain; charset="UTF-8"

This is a body with footer
------------------------------
*Beep, boop, I'm a bot!*
This email was automatically sent from one of Zachary's servers.

--000000000000410b9505ac009d02
Content-Type: text/html; charset="UTF-8"

This is a body with footer<hr width="100%"><center><address><b>Beep, boop, I&#39;m a bot!</b><br>This email was automatically sent from one of Zachary&#39;s servers.</address></center>

--000000000000410b9505ac009d02--
```
![gmail_html](https://user-images.githubusercontent.com/16106076/89236868-ba57af80-d5bf-11ea-8963-ba901c321740.png)
