### PR TITLE
corrupted attachments bugfix

### DIFF
--- a/src/ezgmail/__init__.py
+++ b/src/ezgmail/__init__.py
@@ -33,6 +33,7 @@ from email.mime.base import MIMEBase
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email import encoders
 import mimetypes
 import os
 import datetime
@@ -571,6 +572,7 @@ def _createMessageWithAttachments(sender, recipient, subject, body, attachments,
             else:
                 mimePart = MIMEBase(main_type, sub_type)
                 mimePart.set_payload(fp.read())
+                encoders.encode_base64(mimePart)
         fp.close()
 
         filename = os.path.basename(attachment)


### PR DESCRIPTION
I noticed some PDF I send with EZGmail are corrupted.

This solution is from https://stackoverflow.com/questions/55086946/corrupted-pdf-after-sending-via-gmail-api

I am not sure if 'encoders.encode_base64(mimePart)' should be also added after 'MIMEImage' and 'MIMEAudio' lines.