### PR TITLE
Make SCOPES a list as Google OAuth client expects

### DIFF
--- a/src/ezgmail/__init__.py
+++ b/src/ezgmail/__init__.py
@@ -43,7 +43,7 @@ __version__ = "2024.12.3"
 
 
 # SCOPES = 'https://www.googleapis.com/auth/gmail.readonly' # read-only mode
-SCOPES = "https://mail.google.com/"  # read-write mode
+SCOPES = ["https://mail.google.com/"]  # read-write mode
 SERVICE_GMAIL = None
 EMAIL_ADDRESS = False  # False if not logged in, otherwise the string of the email address of the logged in user.
 LOGGED_IN = False  # False if not logged in, otherwise True


### PR DESCRIPTION
Hi there,

I opened issue #53 a few days ago after realizing that this library stopped working once the credentials expired and needed to be (automatically) refreshed. It turned out to just be due to the `SCOPES` global being a string, while the Google OAuth client was expecting a list of strings. This is the only change I made, as everything seemed to work normally after this in my testing. Let me know if I can provide more information!